### PR TITLE
Fix the problem with interactive mode

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -126,7 +126,7 @@ pub fn limit_per_date(migration_number: &str, days: u32) -> bool {
     e > n
 }
 
-/// Fit a number into the given size allowed (14 chars).
+/// Fit a number into the given size allowed (16 chars).
 ///
 /// # Arguments
 ///


### PR DESCRIPTION
Fix the problem with interactive mode where the terminal doesn't clean up well if the terminal is too small (migrations takes more than one line)
